### PR TITLE
Update downloads-statistics.html

### DIFF
--- a/templates/downloads-statistics.html
+++ b/templates/downloads-statistics.html
@@ -61,7 +61,7 @@
     <script src="https://code.highcharts.com/modules/exporting.js"></script>
     <script type="text/javascript" charset="utf-8">
       $(function () {
-        $.getJSON( "http://hackncast.org/stats/eps/hnc", function(data){
+        $.getJSON( "https://hackncast.org/stats/eps/hnc", function(data){
           var count_total = [];
           var count_month = [];
           var count_week = [];


### PR DESCRIPTION
Avoid `Mixed Content: The page at 'https://hackncast.org/download-stats' was
loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint
'http://hackncast.org/stats/eps/hnc'. This request has been blocked; the
content must be served over HTTPS.`